### PR TITLE
added scidataflow asset feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2015,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "scidataflow"
-version = "0.8.2"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scidataflow"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 exclude = ["logo.png", "tests/test_data/**"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -306,6 +306,23 @@ kept in the Data Manifest. You can set this manually with:
 $ sdf metadata --title "genomics_analysis" --description "A re-analysis of Joan's data."
 ```
 
+## SciDataFlow Assets
+
+Good scientific workflows should create shareable **Scientific Assets** that
+are *trivial* to download and build upon in your own scientific work.
+SciDataFlow makes this possible, since in essence each `data_manifest.yml` file
+is like a minimal recipe specification for also how to *retrieve* data.  The
+`sdf asset` command simply downloads a `data_manifest.yml` from
+SciDataFlow-Assets, another GitHub repository, or URL. After this is
+downloaded, all files can be retrieved in one line:
+
+    $ sdf asset nygc_gatk_1000G_highcov
+    $ sdf pull --all
+
+The idea of SciDataFlow-Assets is to have a open, user-curated collection of
+these recipes at https://github.com/scidataflow-assets. Please contribute
+an Asset when you release new data with a paper!
+
 ## SciDataFlow's Vision
 
 The larger vision of SciDataFlow is to change how data flows through scientific

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod lib {
     pub mod macros;
     pub mod remote;
     pub mod utils;
+    pub mod assets;
     pub mod test_utilities;
 }
 


### PR DESCRIPTION
Adds a way to download `data_manifest.yml` from [SciDataFlow-Assets](https://github.com/scidataflow-assets), GitHub repositories, or other URLs. 