### PR TITLE
fixed bug with sdf update and added --all option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2015,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "scidataflow"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scidataflow"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2021"
 exclude = ["logo.png", "tests/test_data/**"]
 license = "MIT"

--- a/src/lib/data.rs
+++ b/src/lib/data.rs
@@ -388,7 +388,6 @@ impl DataFile {
         path_context.join(&self.path).exists()
     }
 
-
     // Returns true if the file does not exist.
     pub async fn is_changed(&self, path_context: &Path) -> Result<bool> {
         match self.get_md5(path_context).await? {
@@ -571,6 +570,8 @@ impl DataCollection {
                 if let Some(data_file) = self.files.get_mut(file) {
                     data_file.update(path_context).await?;
                     debug!("rehashed file {:?}", data_file.path);
+                } else {
+                    return Err(anyhow!("File '{}' does not exist.", file));
                 }
             }
             None => {

--- a/tests/test_project.rs
+++ b/tests/test_project.rs
@@ -100,7 +100,8 @@ mod tests {
         let re_add_files = vec![file_to_check.to_string_lossy().to_string()];
 
         for file in &re_add_files {
-            let result = fixture.project.update(Some(&file)).await;
+            let files = vec![file.clone()];
+            let result = fixture.project.update(Some(&files)).await;
             assert!(result.is_ok(), "re-adding raised Error!");
         }
         


### PR DESCRIPTION
Fixes a bug where `sdf update` would silently fail if it could not find the file (which it couldn't due, as the paths weren't handled correctly. 

I will also add this testing problem as a new issue: https://github.com/vsbuffalo/scidataflow/issues/6