### PR TITLE
This is a shim to fix an upstream issue in Zenodo's API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /tests/test_data/
+project_test/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scidataflow"
-version = "0.8.9"
+version = "0.8.10"
 edition = "2021"
 exclude = ["logo.png", "tests/test_data/**"]
 license = "MIT"

--- a/src/lib/api/zenodo.rs
+++ b/src/lib/api/zenodo.rs
@@ -57,10 +57,21 @@ pub struct ZenodoFileUpload {
     delete_marker: bool,
 }
 
+// NOTE: this is a shim to address issue #16. This is caused by an upstream
+// bug in Zenodo.
+fn deserialize_filesize<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let filesize_float: f64 = serde::Deserialize::deserialize(deserializer)?;
+    Ok(filesize_float.trunc() as usize)
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ZenodoFile {
     checksum: String,
     filename: String,
+    #[serde(deserialize_with = "deserialize_filesize")]
     filesize: usize,
     id: String,
     links: ZenodoLinks,


### PR DESCRIPTION
See issue #16. I have decided to pull this change into main and push to crates, to restore functionality. 

 - This converrts the float returned by Zenodo's API for `filesize` into a `usize` via serde. This change may be rolled back, if the Zenodo API changes back. However, this restores functionality in the meantime.